### PR TITLE
Fix/Simplify Addressing Modes

### DIFF
--- a/crates/aebytecode/src/code.rs
+++ b/crates/aebytecode/src/code.rs
@@ -319,6 +319,7 @@ impl Serializable for Vec<Arg> {
 impl Serializable for AddressingMode {
     fn serialize(&self) -> Result<Bytes, SerErr> {
         match self {
+            Self::NoArgs => Ok(vec![]),
             Self::Short(low) => Ok(vec![*low]),
             Self::Long { high, low } => Ok(vec![*low, *high]),
         }


### PR DESCRIPTION
This mainly meant adding a None case to the AddressingMode enum, but I also simplified the logic while I was there, in the hopes of making it clearer to anyone else how Aeternity serialization works.