### PR TITLE
Make contracts Clone and Default

### DIFF
--- a/crates/aebytecode/src/code.rs
+++ b/crates/aebytecode/src/code.rs
@@ -326,7 +326,7 @@ impl Serializable for AddressingMode {
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct Contract {
     pub code: Vec<Function>,
     pub symbols: Symbols,
@@ -339,17 +339,17 @@ pub struct Code {
     pub functions: BTreeMap<Bytes, Function>,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct Symbols {
     pub symbols: BTreeMap<Bytes, String>,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum Annotation {
     Comment { line: u32, comment: String },
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct Id {
     pub id_str: String,
 }
@@ -360,7 +360,7 @@ impl Id {
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct Function {
     pub id: Id,
     pub attributes: Attributes,
@@ -376,7 +376,7 @@ pub enum Attributes {
     PrivatePayable = 3,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct TypeSig {
     pub args: Vec<Type>,
     pub ret: Type,

--- a/crates/aebytecode/src/gen.rs
+++ b/crates/aebytecode/src/gen.rs
@@ -107,7 +107,7 @@ pub fn generate_instructions_enum() -> std::io::Result<()> {
     file += "        high: u8,\n";
     file += "    }\n";
     file += "}\n";
-    file += "#[derive(Debug, PartialEq, Eq)]\n";
+    file += "#[derive(Debug, Clone, PartialEq, Eq)]\n";
     file += "pub enum Instruction {\n";
     for i in &instructions.instruction {
         if i.format.is_empty() {

--- a/crates/aebytecode/src/instruction.rs
+++ b/crates/aebytecode/src/instruction.rs
@@ -8,7 +8,7 @@ pub enum AddressingMode {
         high: u8,
     }
 }
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Instruction {
     Return,
     Returnr(Arg),


### PR DESCRIPTION
The backend needs this for cacheing library functions between contracts, and for initializing the contract it is building.